### PR TITLE
Add ARM64 support for the Tanzu CLI

### DIFF
--- a/.github/workflows/test-tanzu-cli.yml
+++ b/.github/workflows/test-tanzu-cli.yml
@@ -5,7 +5,7 @@ jobs:
   test-latest:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, macos-latest-large] # macos-latest is ARM64 while macos-latest-large is x86
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ asdf install bosh 7.0.0
 asdf global bosh 7.0.0
 ```
 
-To manually install use the following, where tool name is one of the support tools listed above:
+To manually install use the following, where tool name is one of the supported tools listed above:
 ```
 asdf plugin-add <tool name> https://github.com/vmware-tanzu/tanzu-plug-in-for-asdf.git
 ```

--- a/bin/download
+++ b/bin/download
@@ -9,15 +9,16 @@ set -euo pipefail
 readonly script_dir="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 readonly file_name="$(basename "$(dirname "${script_dir}")")"
 readonly os=$(uname -s |awk '{print tolower($0)}')
+readonly arch=$(a=$(uname -m) && ([ $a = aarch64 ] || [ $a = arm64 ]) && printf arm64 || printf amd64)
 readonly version=$ASDF_INSTALL_VERSION
 readonly asdf_download_path=$ASDF_DOWNLOAD_PATH
 readonly download_dir="$(mktemp -d -t "asdf_${file_name}_XXXXXXXX")"
 trap 'rm -rf "${download_dir}"' EXIT
 
-. "${script_dir}/../products.inc.sh" "${file_name}" "${version}" "${os}"
+. "${script_dir}/../products.inc.sh" "${file_name}" "${version}" "${os}" "${arch}"
 
-if [[ ${MISSING_PRODUCTS[*]} =~ "${file_name}_${os}" ]]; then
-  echo -e "\nError message: ${file_name} is not available for OS type ${os}\n" >&2
+if [[ ${MISSING_PRODUCTS[*]} =~ "${file_name}_${os}_${arch}" ]]; then
+  echo -e "\nError message: ${file_name} is not available for OS type ${os}_${arch}\n" >&2
   exit 1
 fi
 

--- a/products.inc.sh
+++ b/products.inc.sh
@@ -11,6 +11,7 @@ setEnv() {
   local product="${1:-}"
   local v="${2:-}"
   local o="${3:-}"
+  local a="${4:-}"
 
   # To add a product create a case statement matching the file name and add variables as follows
   # REPO_SLUG
@@ -78,8 +79,13 @@ setEnv() {
       VERSION_COMMAND='version'
       ;;
     tanzu)
+      # Tanzu CLI only started supporting ARM64 natively for darwin with version 1.1.0*
+      # we therefore use the AMD64 version for older versions
+      if [[ "${o}" == "darwin" && "${v}" < "1.1.0" ]]; then
+        a="amd64"
+      fi
       REPO_SLUG='vmware-tanzu/tanzu-cli'
-      PRIMARY_GIT_TEMPLATE="v${v}/tanzu-cli-${o}-amd64.tar.gz"
+      PRIMARY_GIT_TEMPLATE="v${v}/tanzu-cli-${o}-${a}.tar.gz"
       SECONDARY_GIT_TEMPLATE=""
       VERSION_COMMAND='version' #| grep version | sed -n -e "s/^.*version: v//p"
       ;;
@@ -95,9 +101,11 @@ setEnv() {
       ;;
   esac
   
-  # MISSING_PRODUCTS is used to highlight products that aren't available for an OS type
+  # MISSING_PRODUCTS is used to highlight products that aren't available for an OS_ARCH type
   MISSING_PRODUCTS=(
-    "bbr-s3-config-validator_darwin"
+    "bbr-s3-config-validator_darwin_amd64"
+    "bbr-s3-config-validator_darwin_arm64"
+    "tanzu_linux_arm64"
   )
 
   declare -rx REPO_SLUG GIT_FILE_NAME_TEMPLATE VERSION_COMMAND

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -16,7 +16,18 @@ sep=" "
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 repo_dir="$script_dir/.."
 
+function checkBinaryArch() {
+  local plugin_name=$1
+  local wanted_arch=$(a=$(uname -m) && ([ $a = aarch64 ] || [ $a = arm64 ]) && printf arm64 || printf x86)
 
+  # Add below the plugins that install the proper architecture.
+  case $plugin_name in
+  tanzu):
+    echo -e "\nChecking $plugin_name is of arch $wanted_arch"
+    file $(asdf which "$plugin_name") | grep $wanted_arch
+    ;;
+  esac
+}
 
 function test_plugin() {
   local plugin_name=$1
@@ -51,6 +62,8 @@ function test_plugin() {
     echo "Running command '$plugin_name $VERSION_COMMAND'"
     "$plugin_name" "$VERSION_COMMAND"
   fi
+
+  checkBinaryArch $plugin_name
 
   echo -e "\n####### Finished: $plugin_name"
   echo -e "#########################################\n"


### PR DESCRIPTION
This PR takes into consideration the architecture of the machine and installs the Tanzu CLI in ARM64 format on Mac.

Two thing to note:
1. the Tanzu CLI only started supporting darwin ARM64 starting with version 1.1.0, so this PR adds special handling to use AMD64 before version 1.1.0
2. Currently the Linux ARM64 format of the Tanzu CLI is not supported, so this PR adds it to `MISSING_PRODUCTS`.

The changes are backwards-compatible for the other tools supported by this repo.

This PR does not enable ARM64 for the other tools but another PR could easily be done to check which such tools provides such binaries and modify the code to handle this.